### PR TITLE
fix: missing tsm_scratch section in mk_tsm agent-plugin

### DIFF
--- a/.werks/14119
+++ b/.werks/14119
@@ -1,0 +1,13 @@
+Title: Fix ignored site filter on exporting views as PDF report
+Class: fix
+Compatible: compat
+Component: reporting
+Date: 1653052712
+Edition: cee
+Knowledge: doc
+Level: 1
+State: unknown
+Version: 2.2.0i1
+
+If you used site filters in views and the option "Export" -> "This view as
+PDF", the generated report contained all site results.

--- a/.werks/14120
+++ b/.werks/14120
@@ -1,0 +1,13 @@
+Title: Fix error while removing event console rule MKPs
+Class: fix
+Compatible: compat
+Component: wato
+Date: 1653296177
+Edition: cre
+Knowledge: doc
+Level: 1
+State: unknown
+Version: 2.2.0i1
+
+If MKPs with event console rules were removed, the error "list assignment index
+out of range" could occur.

--- a/agents/plugins/mk_tsm
+++ b/agents/plugins/mk_tsm
@@ -56,6 +56,12 @@ EOF
 SELECT 'FOO' as foo,COALESCE(type,'Unknown') as type,stgpools.stgpool_name, sum(coalesce(logical_mb,0)) as SUM_LOGICAL_MB from occupancy full outer join stgpools on occupancy.stgpool_name=stgpools.stgpool_name group by stgpools.stgpool_name,type
 EOF
 
+    # Scratch Tapes
+    echo '<<<tsm_scratch:sep(9)>>>'
+    $dsmcmd <<EOF | sed -n "/^FOO/s//$INST/p"
+SELECT 'FOO', COUNT(*), library_name FROM libvolumes where status='Scratch' group by library_name
+EOF
+
 }
 
 # Find in the list of processes TSM daemons. Example output of 'ps xewwg'


### PR DESCRIPTION
fix: missing tsm_scratch section in mk_tsm agent-plugin

Since the section tsm_scratch is not recorded by the agent, the check "tsm_scratch" is defunct. This PR fixes that problem.

--- snip ---

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
**tsm_scratch check working and displaying the number of available scratch drives**
+ What is the observed behavior?
**tsm_scratch check defunct, agent does not record tsm_scratch section in output**
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
**apparently not: https://forum.checkmk.com/t/tsm-scratch-not-checked/18256**
